### PR TITLE
Fix missing XML documentation.

### DIFF
--- a/Container.cs
+++ b/Container.cs
@@ -84,6 +84,9 @@ namespace Microsoft.MinIoC
         /// <returns>Scope object</returns>
         public IScope CreateScope() => new ScopeLifetime(_lifetime);
 
+        /// <summary>
+        /// Disposes any <see cref="IDisposable"/> objects owned by this container.
+        /// </summary>
         public void Dispose() => _lifetime.Dispose();
         
         #region Lifetime management
@@ -214,6 +217,7 @@ namespace Microsoft.MinIoC
         /// Registers an implementation type for the specified interface
         /// </summary>
         /// <typeparam name="T">Interface to register</typeparam>
+        /// <param name="container">This container instance</param>
         /// <param name="type">Implementing type</param>
         /// <returns>IRegisteredType object</returns>
         public static Container.IRegisteredType Register<T>(this Container container, Type type)
@@ -223,6 +227,7 @@ namespace Microsoft.MinIoC
         /// Registers a factory function which will be called to resolve the specified interface
         /// </summary>
         /// <typeparam name="T">Interface to register</typeparam>
+        /// <param name="container">This container instance</param>
         /// <param name="factory">Factory method</param>
         /// <returns>IRegisteredType object</returns>
         public static Container.IRegisteredType Register<T>(this Container container, Func<T> factory)

--- a/Tests/ContainerTests.cs
+++ b/Tests/ContainerTests.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.MinIoC.Tests
 {
+#pragma warning disable 1591
     [TestClass]
     public class ContainerTests
     {
@@ -291,4 +292,5 @@ namespace Microsoft.MinIoC.Tests
         }
         #endregion
     }
+#pragma warning restore 1591
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -28,6 +28,8 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Tests.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -36,6 +38,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Tests.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">


### PR DESCRIPTION
I'm not sure what you think of turning on XML doc generation during build & warnings as errors. It's the best way I'm aware of to have the compiler help, though it does come at the expense of perhaps longer compilation times to do the XML generation every time. Let me know what you think.