### PR TITLE
Keep shared source types internal.

### DIFF
--- a/Container.cs
+++ b/Container.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MinIoC
     /// <summary>
     /// Inversion of control container handles dependency injection for registered types
     /// </summary>
-    public class Container : Container.IScope
+    class Container : Container.IScope
     {
         #region Public interfaces
         /// <summary>
@@ -208,7 +208,7 @@ namespace Microsoft.MinIoC
     /// <summary>
     /// Extension methods for Container
     /// </summary>
-    public static class ContainerExtensions
+    static class ContainerExtensions
     {
         /// <summary>
         /// Registers an implementation type for the specified interface


### PR DESCRIPTION
Thoughts on this change?

Motivation:
1. In general, for shared source, public can cause conflicts. If A.dll and B.dll both include this file, they'd both expose a public type with the same name in the same namespace.
2. In one project we're using, using Container is an internal implementation detail and not a surface area we're intending to expose to our customers. (They'd be free to use their own copy of Container if they like since it's shared source.)
