### PR TITLE
Omit default access modifiers

### DIFF
--- a/Container.cs
+++ b/Container.cs
@@ -40,10 +40,10 @@ namespace Microsoft.MinIoC
         #endregion
 
         // Map of registered types
-        private Dictionary<Type, Func<ILifetime, object>> _registeredTypes = new Dictionary<Type, Func<ILifetime, object>>();
+        Dictionary<Type, Func<ILifetime, object>> _registeredTypes = new Dictionary<Type, Func<ILifetime, object>>();
 
         // Lifetime management
-        private ContainerLifetime _lifetime;
+        ContainerLifetime _lifetime;
 
         /// <summary>
         /// Creates a new instance of IoC Container
@@ -68,7 +68,7 @@ namespace Microsoft.MinIoC
         public IRegisteredType Register(Type @interface, Type implementation)
             => RegisterType(@interface, FactoryFromType(implementation));
 
-        private IRegisteredType RegisterType(Type itemType, Func<ILifetime, object> factory)
+        IRegisteredType RegisterType(Type itemType, Func<ILifetime, object> factory)
             => new RegisteredType(itemType, f => _registeredTypes[itemType] = f, factory);
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Microsoft.MinIoC
         abstract class ObjectCache
         {
             // Instance cache
-            private ConcurrentDictionary<Type, object> _instanceCache = new ConcurrentDictionary<Type, object>();
+            ConcurrentDictionary<Type, object> _instanceCache = new ConcurrentDictionary<Type, object>();
 
             // Get from cache or create and cache object
             protected object GetCached(Type type, Func<ILifetime, object> factory, ILifetime lifetime)
@@ -135,7 +135,7 @@ namespace Microsoft.MinIoC
         class ScopeLifetime : ObjectCache, ILifetime
         {
             // Singletons come from parent container's lifetime
-            private ContainerLifetime _parentLifetime;
+            ContainerLifetime _parentLifetime;
 
             public ScopeLifetime(ContainerLifetime parentContainer) => _parentLifetime = parentContainer;
 
@@ -153,7 +153,7 @@ namespace Microsoft.MinIoC
 
         #region Container items
         // Compiles a lambda that calls the given type's first constructor resolving arguments
-        private static Func<ILifetime, object> FactoryFromType(Type itemType)
+        static Func<ILifetime, object> FactoryFromType(Type itemType)
         {
             // Get first constructor for the type
             var constructors = itemType.GetConstructors();

--- a/Container.cs
+++ b/Container.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MinIoC
     /// <summary>
     /// Inversion of control container handles dependency injection for registered types
     /// </summary>
-    public class Container : Container.IScope
+    class Container : Container.IScope
     {
         #region Public interfaces
         /// <summary>
@@ -208,7 +208,7 @@ namespace Microsoft.MinIoC
     /// <summary>
     /// Extension methods for Container
     /// </summary>
-    public static class ContainerExtensions
+    static class ContainerExtensions
     {
         /// <summary>
         /// Registers an implementation type for the specified interface


### PR DESCRIPTION
For consistency with omitting default access modifiers on types. Or if you prefer keeping them on methods and want to leave as-is, that's fine too.