### PR TITLE
Implement IServiceProvider correctly.

### DIFF
--- a/Container.cs
+++ b/Container.cs
@@ -72,11 +72,21 @@ namespace Microsoft.MinIoC
             => new RegisteredType(itemType, f => _registeredTypes[itemType] = f, factory);
 
         /// <summary>
-        /// Returns the object registered for the given type
+        /// Returns the object registered for the given type, if registered
         /// </summary>
         /// <param name="type">Type as registered with the container</param>
-        /// <returns>Instance of the registered type</returns>
-        public object GetService(Type type) => _registeredTypes[type](_lifetime);
+        /// <returns>Instance of the registered type, if registered; otherwise <see langword="null"/></returns>
+        public object GetService(Type type)
+        {
+            Func<ILifetime, object> registeredType;
+
+            if (!_registeredTypes.TryGetValue(type, out registeredType))
+            {
+                return null;
+            }
+
+            return registeredType(_lifetime);
+        }
 
         /// <summary>
         /// Creates a new scope

--- a/Tests/ContainerTests.cs
+++ b/Tests/ContainerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.MinIoC.Tests
@@ -243,6 +244,28 @@ namespace Microsoft.MinIoC.Tests
             container2.Register<IFoo>(typeof(Foo)).AsSingleton();
 
             Assert.AreNotEqual(container1.Resolve<IFoo>(), container2.Resolve<IFoo>());
+        }
+
+        [TestMethod]
+        public void GetServiceUnregisteredTypeReturnsNull()
+        {
+            using (var container = new Container())
+            {
+                object value = container.GetService(typeof(Foo));
+
+                Assert.IsNull(value);
+            }
+        }
+
+        [TestMethod]
+        public void GetServiceMissingDependencyThrows()
+        {
+            using (var container = new Container())
+            {
+                container.Register<Bar>();
+
+                Assert.ThrowsException<KeyNotFoundException>(() => container.GetService(typeof(Bar)));
+            }
         }
 
         #region Types used for tests


### PR DESCRIPTION
For an unregistered type, IServiceProvider.GetService returns null. See:
https://docs.microsoft.com/en-us/dotnet/api/system.iserviceprovider.getservice